### PR TITLE
Debug visualize SDF using high contrast colors

### DIFF
--- a/Editor/SDFTexture.shader
+++ b/Editor/SDFTexture.shader
@@ -32,6 +32,8 @@
 
     #define COLOR_POS 1
     #define COLOR_NEG float3(0.72, 0, 1)
+
+    int _HighContrast;
     
     v2f vert(appdata v)
     {
@@ -51,7 +53,15 @@
             uvw = float3(i.texcoord.x, _Z, i.texcoord.y);
         
         float dist = tex3D(_SDF, uvw).r * _DistanceScale;
-        float3 color = dist > 0.0 ? dist * COLOR_POS : -dist * COLOR_NEG;
+        float3 color;
+        if(_HighContrast == 1)
+        {
+            color = dist > 0.0 ? float3(1, 1, 1) : float3(0, 0, 0);
+        }
+        else
+        {
+            color = dist > 0.0 ? dist * COLOR_POS : -dist * COLOR_NEG;
+        }
         return float4(color, 1);
     }
     ENDHLSL

--- a/Editor/SDFTextureEditor.cs
+++ b/Editor/SDFTextureEditor.cs
@@ -11,6 +11,7 @@ public class SDFTextureEditor : Editor
     static Material s_Material;
     static float s_Slice = 0.5f; // [0, 1]
     static Axis s_Axis = Axis.X;
+    static bool s_HighContrast = false;
 
     SerializedProperty m_SDF;
     SerializedProperty m_Size;
@@ -22,6 +23,7 @@ public class SDFTextureEditor : Editor
         internal static int _Mode = Shader.PropertyToID("_Mode");
         internal static int _Axis = Shader.PropertyToID("_Axis");
         internal static int _DistanceScale = Shader.PropertyToID("_DistanceScale");
+        internal static int _HighContrast = Shader.PropertyToID("_HighContrast");
     }
 
     void OnEnable()
@@ -96,6 +98,7 @@ public class SDFTextureEditor : Editor
         s_Material.SetVector("_VoxelResolution", new Vector4(voxelResolution.x, voxelResolution.y, voxelResolution.z));
         s_Material.SetFloat(Uniforms._DistanceScale, distanceScale);
         s_Material.SetTexture("_SDF", sdf);
+        s_Material.SetInt(Uniforms._HighContrast, s_HighContrast ? 1 : 0);
 
         s_Material.SetPass(0);
         Graphics.DrawMeshNow(s_Quad, matrix);
@@ -183,6 +186,8 @@ public class SDFTextureEditor : Editor
             s_Slice = slice;
             SceneView.lastActiveSceneView?.Repaint();
         }
+
+        s_HighContrast = EditorGUILayout.Toggle(new GUIContent("High Contrast", "Draw SDF visualisation using high contrast colors."), s_HighContrast);
     }
 
     bool HasFrameBounds()


### PR DESCRIPTION
Add a Debug Toggle in SDFTextureEditor to visualize SDF using high contrast colors.
It can help quickly match 3D objects with SDFTexture areas in the editor.


Inspector Setting
![SDF Texture Inspector Setting](https://github.com/user-attachments/assets/5afc40e9-2692-4149-9bce-a8bb50617f56)

Before Set High Contrast
![SDF Texture Debug In Scene 1](https://github.com/user-attachments/assets/a1244ef0-3ad3-4224-be3c-70f5f7981990)

After Set High Contrast
![SDF Texture Debug In Scene 2](https://github.com/user-attachments/assets/69b7a932-cccd-4a54-95cb-f41e7434882f)

